### PR TITLE
[docs]:correct paper title

### DIFF
--- a/src/feature_bank/feature_bank.py
+++ b/src/feature_bank/feature_bank.py
@@ -1,7 +1,7 @@
 """Source code for the Feature Bank of the StreamV2V paper.
 
 References:
-    StreamV2V: A Deep Generative Model for High-fidelity View Synthesis - Liang et al.,
+    StreamV2V: Looking Backward: Streaming Video-to-Video Translation with Feature Banks - Liang et al.,
     2025, URL: https://arxiv.org/abs/2405.15757
 """
 


### PR DESCRIPTION
This PR just corrects the paper title of `StreamV2V` in the docstring.
cc @rickstaa 