### PR TITLE
Add pyproject.toml for Custom Node Registry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "stream-pack"
 description = "A suite of custom ComfyUI nodes for building real-time video and audio workflows using ComfyStream."
 version = "1.0.0"
 license = {file = "LICENSE"}
-dependencies = ["mediapipe", "torch", "diffusers"]
+dynamic = ["dependencies"]
 
 [project.urls]
 Repository = "https://github.com/livepeer/ComfyUI-Stream-Pack"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,6 @@ Repository = "https://github.com/livepeer/ComfyUI-Stream-Pack"
 #  Used by Comfy Registry https://comfyregistry.org
 
 [tool.comfy]
-PublisherId = ""
+PublisherId = "livepeer-comfystream"
 DisplayName = "ComfyUI-Stream-Pack"
 Icon = ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[project]
+name = "stream-pack"
+description = "A suite of custom ComfyUI nodes for building real-time video and audio workflows using ComfyStream."
+version = "1.0.0"
+license = {file = "LICENSE"}
+dependencies = ["mediapipe", "torch", "diffusers"]
+
+[project.urls]
+Repository = "https://github.com/livepeer/ComfyUI-Stream-Pack"
+#  Used by Comfy Registry https://comfyregistry.org
+
+[tool.comfy]
+PublisherId = ""
+DisplayName = "ComfyUI-Stream-Pack"
+Icon = ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,4 +12,7 @@ Repository = "https://github.com/livepeer/ComfyUI-Stream-Pack"
 [tool.comfy]
 PublisherId = "livepeer-comfystream"
 DisplayName = "ComfyUI-Stream-Pack"
-Icon = ""
+Icon = "https://raw.githubusercontent.com/livepeer/comfystream-docs/main/logo/icon-light-120px.svg"
+
+[tool.setuptools.dynamic]
+dependencies = {file = ["requirements.txt"]}


### PR DESCRIPTION
Hey! My name is Robin and I'm from [comfy-org](https://comfy.org/)! We would love to have you join the Comfy Registry, a public collection of custom nodes which lets authors publish nodes by version and automate testing against existing workflows. 

The registry is already integrated with ComfyUI-Manager, and we want it to be the default place users install nodes from eventually. We do a security-scan of every node to improve safety. Feel free to read up more on the registry [here](https://docs.comfy.org/registry/overview#introduction)

Action Required:

- [ ] Go to the [registry](https://registry.comfy.org). Login and create a publisher id (everything after the `@` sign on your registry profile). 
- [ ] Add the publisher id into the pyproject.toml file.
- [ ] Merge the separate Github Actions PR, then merge this PR.

If you want to publish the node manually, [install the cli](https://docs.comfy.org/comfy-cli/getting-started#install-cli) by running `pip install comfy-cli`, then run `comfy node publish`

Otherwise, if you have any questions, please message me on discord at robinken or join our [server](https://discord.com/invite/comfyorg)!