### PR TITLE
nodes(transcription): allow up to 192000 sample rate, default to 16000khz for whisper

### DIFF
--- a/src/audio_transcription/transcription_nodes.py
+++ b/src/audio_transcription/transcription_nodes.py
@@ -92,8 +92,14 @@ class AudioTranscriptionNode:
     def INPUT_TYPES(cls):
         return {
             "required": {
-                "audio": ("WAVEFORM",),  # Input from LoadAudioTensor
-                "sample_rate": ("INT",),  # Sample rate from LoadAudioTensor
+                "audio": ("WAVEFORM",),
+                "sample_rate": ("INT", {
+                    "default": 16000,
+                    "min": 8000,
+                    "max": 192000,
+                    "step": 1000,
+                    "tooltip": "Sample rate in Hz (16000 recommended)"
+                }),
                 "transcription_interval": ("FLOAT", {
                     "default": 2.0, 
                     "min": 1.0, 


### PR DESCRIPTION
ComfyUI has a default int max of 2048. This modifies the `AudioTranscriptionNode` node to allow up 192000khz sample rate values and sets a default of 16000Khz. 

Clears the Whisper warnings
`2025-09-12 21:29:33 [WARNING] [ComfyUI-Stream-Pack.src.audio_transcription.transcription_nodes] [transcription_nodes.py:481] Non-optimal sample rate 1600Hz for Whisper (16kHz recommended)`
