### PR TITLE
chore: update .gitignore to include Python packaging artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,12 @@
 __pycache__
 *.pyc
 
+# Python packaging
+*.egg-info/
+*.egg-info
+build/
+dist/
+
 # IDEs
 .vscode
 *.code-workspace


### PR DESCRIPTION
This PR updates `.gitignore` to exclude standard `/build` directory and `.egg` python package files that are generated when installed as a package.

Note: pip install is not necessary or recommended, but it works as an alternative way to install due to pyproject.toml now present from #22